### PR TITLE
Fix quotes in services.yaml

### DIFF
--- a/custom_components/ai_agent_ha/services.yaml
+++ b/custom_components/ai_agent_ha/services.yaml
@@ -1,7 +1,7 @@
 query:
-  name: “Query LLaMA with Home Assistant context”
-  description: “Run a custom LLaMA prompt against your HA state dump.”
+  name: "Query AI Agent with Home Assistant context"
+  description: "Run a custom prompt with the AI Agent using your HA state dump."
   fields:
     prompt:
-      description: “The question or instruction to send to the LLaMA model.”
-      example: “Which rooms have lights on?”
+      description: "The question or instruction to send to the AI Agent."
+      example: "Which rooms have lights on?"


### PR DESCRIPTION
## Summary
- use standard quotes in service description
- refer to the provider-agnostic **AI Agent**

## Testing
- `hassfest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a13354988324a5a81d8809e7e1af