### PR TITLE
Validate API key on agent init

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -149,6 +149,11 @@ class AiAgentHaAgent:
         self._last_request_time = 0
         self._request_count = 0
         self._request_window_start = time.time()
+        # Validate the API key before initializing the client
+        if not self._validate_api_key():
+            _LOGGER.error("Invalid API key provided")
+            raise ValueError("Invalid API key")
+
         provider = config.get("ai_provider", "llama")
         _LOGGER.debug("Initializing AiAgentHaAgent with provider: %s", provider)
         if provider == "openai":


### PR DESCRIPTION
## Summary
- validate API key when creating `AiAgentHaAgent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a1423bb883248c86ed35e513a786