### PR TITLE
Add persistent memory for entity and UI data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Home Assistant custom component that provides an AI-powered agent capable of g
 * **Entity-Aware**: Automatically discovers and uses your existing Home Assistant entities.
 * **UI Integration**: Manage and approve suggested automations directly from Home Assistant's UI (see screenshot below).
 * **Dashboard Creation**: Build Lovelace dashboards and cards using natural language.
+* **Persistent Memory**: Stores entity states, automations and dashboard data between restarts.
 
 ![AI Agent HA Usage Screenshot](./image/Screenshot.png)
 
@@ -45,7 +46,19 @@ git clone https://github.com/sbenodiz/ai_agent_ha.git
 
 ## Configuration
 
-The integration will automatically register a new panel in the sidebar named **AI Agent HA**. No YAML configuration is required. 
+The integration will automatically register a new panel in the sidebar named **AI Agent HA**. No YAML configuration is required.
+
+### Persistent Memory
+
+Starting with this release, the integration keeps a local memory file storing recent entity states, created automations and dashboards. This context is loaded when Home Assistant starts and saved periodically.
+
+Configuration options:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `memory_refresh_interval` | Minutes between automatic memory updates | `10` |
+| `memory_file` | Filename for the stored memory (relative to the Home Assistant config directory) | `ai_agent_ha_memory.json` |
+
 ---
 
 ## Usage

--- a/custom_components/ai_agent_ha/__init__.py
+++ b/custom_components/ai_agent_ha/__init__.py
@@ -2,19 +2,22 @@
 from __future__ import annotations
 
 import logging
-import json
-import aiohttp
 import voluptuous as vol
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import dt as dt_util
 from homeassistant.components import websocket_api
 from homeassistant.components.frontend import async_register_built_in_panel
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.exceptions import ConfigEntryNotReady
-from .const import DOMAIN, CONF_API_KEY, CONF_WEATHER_ENTITY
+from .const import (
+    DOMAIN,
+    CONF_API_KEY,
+    CONF_WEATHER_ENTITY,
+    CONF_MEMORY_FILE,
+    CONF_MEMORY_REFRESH_INTERVAL,
+)
 from .agent import AiAgentHaAgent
 from homeassistant.components.http import StaticPathConfig
 

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -22,7 +22,14 @@ from typing import Dict, Any, List, Optional
 from datetime import datetime, timedelta
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
-from .const import DOMAIN, CONF_WEATHER_ENTITY
+from homeassistant.helpers.event import async_track_time_interval
+from .const import (
+    DOMAIN,
+    CONF_WEATHER_ENTITY,
+    CONF_MEMORY_FILE,
+    CONF_MEMORY_REFRESH_INTERVAL,
+)
+from .memory import MemoryStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -137,7 +144,11 @@ class AiAgentHaAgent:
     SYSTEM_PROMPT = {
         "role": "system",
         "content": (
-            "You are an AI assistant integrated with Home Assistant.\n"
+            "You are an AI assistant integrated with Home Assistant. "
+            "Your context is stored persistently, keeping entity states, created "
+            "automations and dashboards between restarts. "
+            "Use load_memory() to refresh this context and save_memory() to "
+            "persist your updates.\n"
             "You can request specific data by using only these commands:\n"
             "- get_entity_state(entity_id): Get state of a specific entity\n"
             "- get_entities_by_domain(domain): Get all entities in a domain\n"
@@ -210,6 +221,17 @@ class AiAgentHaAgent:
             self.ai_client = AnthropicClient(config.get("api_key"))
         else:
             self.ai_client = LlamaClient(config.get("api_key"))
+
+        self.memory_store = MemoryStore(
+            hass,
+            config.get(CONF_MEMORY_FILE, "ai_agent_ha_memory.json"),
+        )
+        self._memory_refresh_interval = timedelta(
+            minutes=config.get(CONF_MEMORY_REFRESH_INTERVAL, 10)
+        )
+        hass.async_create_task(self.initialize_memory())
+        async_track_time_interval(hass, self.refresh_memory, self._memory_refresh_interval)
+
         _LOGGER.debug("AiAgentHaAgent initialized successfully")
 
     def _validate_api_key(self) -> bool:
@@ -244,6 +266,34 @@ class AiAgentHaAgent:
     def _set_cached_data(self, key: str, data: Any) -> None:
         """Store data in cache with timestamp."""
         self._cache[key] = (time.time(), data)
+
+    async def initialize_memory(self) -> None:
+        """Load persistent memory and refresh state."""
+        await self.memory_store.load()
+        await self.refresh_memory()
+
+    async def refresh_memory(self, _=None) -> None:
+        """Refresh stored entity states and persist to disk."""
+        try:
+            self.memory_store.data["entities"] = {
+                state.entity_id: {
+                    "state": self._serialize(state.state),
+                    "attributes": {k: self._serialize(v) for k, v in state.attributes.items()},
+                    "last_changed": state.last_changed.isoformat() if state.last_changed else None,
+                }
+                for state in self.hass.states.async_all()
+            }
+            await self.memory_store.save()
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.error("Failed to refresh memory: %s", err)
+
+    async def load_memory(self) -> None:
+        """Public wrapper to load memory."""
+        await self.memory_store.load()
+
+    async def save_memory(self) -> None:
+        """Public wrapper to save memory."""
+        await self.memory_store.save()
 
     def _serialize(self, value: Any) -> Any:
         """Recursively convert values to JSON serializable formats."""
@@ -294,6 +344,8 @@ class AiAgentHaAgent:
                 "attributes": {k: self._serialize(v) for k, v in state.attributes.items()}
             }
             _LOGGER.debug("Retrieved entity state: %s", json.dumps(result, default=str))
+            self.memory_store.data.setdefault("entities", {})[entity_id] = result
+            await self.memory_store.save()
             return result
         except Exception as e:
             _LOGGER.exception("Error getting entity state: %s", str(e))
@@ -609,7 +661,10 @@ class AiAgentHaAgent:
             
             # Clear automation-related caches
             self._cache.clear()
-            
+
+            self.memory_store.data.setdefault("automations", []).append(automation_entry)
+            await self.memory_store.save()
+
             return {
                 "success": True,
                 "message": f"Automation '{automation_entry['alias']}' created successfully"
@@ -649,6 +704,8 @@ class AiAgentHaAgent:
                     yaml.dump(dashboards, file, default_flow_style=False)
 
             await self.hass.async_add_executor_job(_write_dashboards)
+            self.memory_store.data.setdefault("dashboards", []).append(dashboard_config)
+            await self.memory_store.save()
 
             return {
                 "success": True,
@@ -688,6 +745,12 @@ class AiAgentHaAgent:
                     yaml.dump(dashboards, file, default_flow_style=False)
 
             await self.hass.async_add_executor_job(_write_dashboards)
+            self.memory_store.data.setdefault("dashboards", [])
+            for db in self.memory_store.data["dashboards"]:
+                if db.get("id") == dashboard_id:
+                    db.setdefault("cards", []).append(card_config)
+                    break
+            await self.memory_store.save()
 
             return {
                 "success": True,

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -16,7 +16,13 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.const import CONF_NAME
 
-from .const import DOMAIN, CONF_API_KEY, CONF_WEATHER_ENTITY
+from .const import (
+    DOMAIN,
+    CONF_API_KEY,
+    CONF_WEATHER_ENTITY,
+    CONF_MEMORY_FILE,
+    CONF_MEMORY_REFRESH_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +63,9 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     title=f"AI Agent HA ({PROVIDERS.get(user_input['ai_provider'], user_input['ai_provider'])})",
                     data={
                         "ai_provider": user_input["ai_provider"],
-                        "api_key": user_input["api_key"]
+                        "api_key": user_input["api_key"],
+                        CONF_MEMORY_REFRESH_INTERVAL: user_input.get(CONF_MEMORY_REFRESH_INTERVAL, 10),
+                        CONF_MEMORY_FILE: user_input.get(CONF_MEMORY_FILE, "ai_agent_ha_memory.json"),
                     },
                 )
             except InvalidApiKey:
@@ -71,6 +79,8 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({
                 vol.Required("ai_provider", default=provider): vol.In(list(PROVIDERS.keys())),
                 vol.Required("api_key"): str,
+                vol.Optional(CONF_MEMORY_REFRESH_INTERVAL, default=10): int,
+                vol.Optional(CONF_MEMORY_FILE, default="ai_agent_ha_memory.json"): str,
             }),
             errors=errors,
             description_placeholders={
@@ -103,7 +113,9 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                     title="",
                     data={
                         "ai_provider": user_input["ai_provider"],
-                        "api_key": user_input["api_key"]
+                        "api_key": user_input["api_key"],
+                        CONF_MEMORY_REFRESH_INTERVAL: user_input.get(CONF_MEMORY_REFRESH_INTERVAL, 10),
+                        CONF_MEMORY_FILE: user_input.get(CONF_MEMORY_FILE, "ai_agent_ha_memory.json"),
                     }
                 )
 
@@ -112,6 +124,8 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema({
                 vol.Required("ai_provider", default=provider): vol.In(list(PROVIDERS.keys())),
                 vol.Required("api_key", default=default_token): str,
+                vol.Optional(CONF_MEMORY_REFRESH_INTERVAL, default=10): int,
+                vol.Optional(CONF_MEMORY_FILE, default="ai_agent_ha_memory.json"): str,
             }),
             errors=errors,
             description_placeholders={

--- a/custom_components/ai_agent_ha/const.py
+++ b/custom_components/ai_agent_ha/const.py
@@ -3,3 +3,5 @@
 DOMAIN = "ai_agent_ha"
 CONF_API_KEY = "api_key"
 CONF_WEATHER_ENTITY = "weather_entity"
+CONF_MEMORY_FILE = "memory_file"
+CONF_MEMORY_REFRESH_INTERVAL = "memory_refresh_interval"

--- a/custom_components/ai_agent_ha/memory.py
+++ b/custom_components/ai_agent_ha/memory.py
@@ -1,0 +1,49 @@
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MemoryStore:
+    """Persistent storage for AI Agent HA."""
+
+    def __init__(self, hass: HomeAssistant, file_name: str | None = None) -> None:
+        self.hass = hass
+        self.file_path = hass.config.path(file_name or "ai_agent_ha_memory.json")
+        self.data: Dict[str, Any] = {
+            "entities": {},
+            "automations": [],
+            "dashboards": [],
+        }
+
+    async def load(self) -> None:
+        """Load memory from disk."""
+        def _load(path: str) -> Dict[str, Any] | None:
+            if Path(path).is_file():
+                with open(path, "r", encoding="utf-8") as file:
+                    return json.load(file)
+            return None
+
+        try:
+            loaded = await self.hass.async_add_executor_job(_load, self.file_path)
+            if isinstance(loaded, dict):
+                self.data.update(loaded)
+            _LOGGER.debug("Memory loaded from %s", self.file_path)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.error("Failed to load memory: %s", err)
+
+    async def save(self) -> None:
+        """Save memory to disk."""
+        def _save(path: str, data: Dict[str, Any]) -> None:
+            with open(path, "w", encoding="utf-8") as file:
+                json.dump(data, file, indent=2)
+
+        try:
+            await self.hass.async_add_executor_job(_save, self.file_path, self.data)
+            _LOGGER.debug("Memory saved to %s", self.file_path)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.error("Failed to save memory: %s", err)


### PR DESCRIPTION
## Summary
- create a new persistent `MemoryStore` for storing entity states, automations and dashboards
- refresh and save memory at startup and on an interval
- update commands to write to the memory store
- expose memory configuration options
- document persistent memory usage
- clean up unused imports
- include persistent memory information in the system prompt

## Testing
- `python -m py_compile custom_components/ai_agent_ha/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844fb0bb0f883248f20ece0789892a3